### PR TITLE
#178619339-bug-customers_shouldnt_control_the_cost

### DIFF
--- a/webmarket/src/main/java/deti/tqs/webmarket/controller/OrderController.java
+++ b/webmarket/src/main/java/deti/tqs/webmarket/controller/OrderController.java
@@ -38,7 +38,12 @@ public class OrderController {
         order.setPaymentType(orderDto.getPaymentType());
         order.setCost(orderDto.getCost());
         order.setLocation(orderDto.getLocation());
-        return new ResponseEntity<>(this.orderService.createOrder(order),
+
+        var response = this.orderService.createOrder(order);
+
+        if (response.getId() == null)
+            return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<>(response,
                 HttpStatus.CREATED);
     }
 }

--- a/webmarket/src/main/java/deti/tqs/webmarket/service/CustomerServiceImp.java
+++ b/webmarket/src/main/java/deti/tqs/webmarket/service/CustomerServiceImp.java
@@ -1,5 +1,8 @@
 package deti.tqs.webmarket.service;
 
+import com.google.maps.model.DistanceMatrixElement;
+import com.google.maps.model.DistanceMatrixElementStatus;
+import com.google.maps.model.DistanceMatrixRow;
 import deti.tqs.webmarket.api.DistanceAPI;
 import deti.tqs.webmarket.dto.CustomerDto;
 import deti.tqs.webmarket.dto.OrderDto;
@@ -164,7 +167,7 @@ public class CustomerServiceImp implements CustomerService {
                 new String[] { destination }
         );
 
-        if (response == null)
+        if (response.rows[0].elements[0].status.equals(DistanceMatrixElementStatus.NOT_FOUND))
             return new PriceEstimationDto();
 
         var rideInfo = response.rows[0].elements[0];

--- a/webmarket/src/main/java/deti/tqs/webmarket/service/OrderServiceImp.java
+++ b/webmarket/src/main/java/deti/tqs/webmarket/service/OrderServiceImp.java
@@ -1,5 +1,6 @@
 package deti.tqs.webmarket.service;
 
+import deti.tqs.webmarket.api.DistanceAPI;
 import deti.tqs.webmarket.cache.OrdersCache;
 import deti.tqs.webmarket.dto.OrderDto;
 import deti.tqs.webmarket.model.Order;
@@ -33,6 +34,9 @@ public class OrderServiceImp implements OrderService {
     @Autowired
     private OrdersCache ordersCache;
 
+    @Autowired
+    private CustomerService customerService;
+
     @Override
     public OrderDto createOrder(OrderDto orderDto){
         var user = this.userRepository.findByUsername(orderDto.getUsername()).orElseThrow(
@@ -41,9 +45,14 @@ public class OrderServiceImp implements OrderService {
 
         var customer = user.getCustomer();
 
+        var price = customerService.getPriceForDelivery(user.getId(), orderDto.getLocation()).getDeliveryPrice();
+
+        if (price == null)
+            return new OrderDto();
+
         var order = new Order(
                orderDto.getPaymentType(),
-               orderDto.getCost(),
+               price,
                customer,
                orderDto.getLocation()
         );

--- a/webmarket/src/test/java/deti/tqs/webmarket/controller/AdminControllerParalellConf_RestTempIT.java
+++ b/webmarket/src/test/java/deti/tqs/webmarket/controller/AdminControllerParalellConf_RestTempIT.java
@@ -48,6 +48,7 @@ public class AdminControllerParalellConf_RestTempIT {
 
     @BeforeEach
     void setUp() {
+        ordersCache.deleteAllOrders();
         user = new User(
                 "Ronaldo",
                 "ronaldo@mail.com",

--- a/webmarket/src/test/java/deti/tqs/webmarket/service/OrderServiceImpTest.java
+++ b/webmarket/src/test/java/deti/tqs/webmarket/service/OrderServiceImpTest.java
@@ -3,6 +3,7 @@ package deti.tqs.webmarket.service;
 import deti.tqs.webmarket.cache.OrdersCache;
 import deti.tqs.webmarket.dto.CustomerDto;
 import deti.tqs.webmarket.dto.OrderDto;
+import deti.tqs.webmarket.dto.PriceEstimationDto;
 import deti.tqs.webmarket.model.Customer;
 import deti.tqs.webmarket.model.Order;
 import deti.tqs.webmarket.model.Rider;
@@ -39,6 +40,9 @@ class OrderServiceImpTest {
 
     @Mock(lenient = true)
     private OrdersCache ordersCache;
+
+    @Mock
+    private CustomerService customerService;
 
     @InjectMocks
     private OrderServiceImp orderServiceImp;
@@ -136,6 +140,13 @@ class OrderServiceImpTest {
     void createOrder_AddToDB_Test() {
         Mockito.when(userRepository.findByUsername("Maria")).thenReturn(java.util.Optional.ofNullable(user));
         Mockito.when(orderRepository.save(Mockito.any(Order.class))).thenReturn(orderFromDB);
+
+        var priceEstimation = new PriceEstimationDto();
+        priceEstimation.setDeliveryPrice(orderCreateDto.getCost());
+
+        Mockito.when(
+                customerService.getPriceForDelivery(orderCreateDtoRet.getCustomerId(), orderCreateDto.getLocation())
+        ).thenReturn(priceEstimation);
 
         var res = orderServiceImp.createOrder(orderCreateDto);
         res.setOrderTimestamp(null);


### PR DESCRIPTION
# bug fix - wedeliver calculates cost of delivery based on the location of the store and the destination address

## What was done
- Simply used the customer service already implemented that allowed to retrieve a price prevision using the location the store and the destination location

## What is now possible
- So now the customer does not have any input relative to cost, the cost of the delivery is calculated by the WeDelivery app.
- After the order is created the cost of it is retrieved to the customer
- The customer can have a preview of that value, using **/api/customer/deliveryprice**